### PR TITLE
Add Flask page for dummy agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
+# OpenAICodex
 
+This repository contains a minimal Flask application that serves a static webpage for experimenting with prompt inputs.
+
+## Features
+- Text area for arbitrary text blocks
+- Separate fields for system and user prompts
+- Generate button that sends the data to a dummy backend agent
+- Output area displaying the dummy agent's response
+
+## Running the app
+1. Install dependencies:
+   ```bash
+   pip install flask
+   ```
+2. Start the development server:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000` in your browser.
+
+The backend currently uses a placeholder agent that simply echoes the submitted values.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,20 @@
+from flask import Flask, render_template, request, jsonify
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    data = request.get_json() or {}
+    system_prompt = data.get('system_prompt', '')
+    user_prompt = data.get('user_prompt', '')
+    text_blocks = data.get('text_blocks', '')
+
+    response_text = f"System: {system_prompt}\nUser: {user_prompt}\nTexts: {text_blocks}\n\n[Dummy agent response]"
+    return jsonify({'output': response_text})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dummy Agent Interface</title>
+</head>
+<body>
+    <h1>Dummy Agent Interface</h1>
+    <div>
+        <label for="text-blocks">Text Blocks:</label><br>
+        <textarea id="text-blocks" rows="6" cols="60"></textarea>
+    </div>
+    <div>
+        <label for="system-prompt">System Prompt:</label><br>
+        <textarea id="system-prompt" rows="4" cols="60"></textarea>
+    </div>
+    <div>
+        <label for="user-prompt">User Prompt:</label><br>
+        <textarea id="user-prompt" rows="4" cols="60"></textarea>
+    </div>
+    <button id="generate-btn">Generate</button>
+    <h2>Output:</h2>
+    <textarea id="output" rows="6" cols="60" readonly></textarea>
+
+    <script>
+        document.getElementById('generate-btn').addEventListener('click', async () => {
+            const response = await fetch('/generate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    text_blocks: document.getElementById('text-blocks').value,
+                    system_prompt: document.getElementById('system-prompt').value,
+                    user_prompt: document.getElementById('user-prompt').value,
+                })
+            });
+            const data = await response.json();
+            document.getElementById('output').value = data.output;
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build basic Flask server with `/` and `/generate` routes
- serve simple interface to collect text blocks, system prompt, and user prompt
- send inputs to a placeholder backend and display combined output

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6895a3d51b84832792547d9c00dab84c